### PR TITLE
ci: Update pull.yml

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -2,7 +2,7 @@ version: "1"
 rules: # Array of rules
   - base: master # Required. Target branch
     upstream: yangzongzhuan:springboot3 # Required. Must be in the same fork network.
-    mergeMethod: squash # Optional, one of [none, merge, squash, rebase, hardreset], Default: none.
+    mergeMethod: rebase # Optional, one of [none, merge, squash, rebase, hardreset], Default: none.
     mergeUnstable: false # Optional, merge pull request even when the mergeable_state is not clean. Default: false
     assignees: # Optional
       - unknowIfGuestInDream


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Changes the merge method from "squash" to "rebase" in the pull.yml GitHub Action configuration for syncing with the upstream springboot3 branch.

- Modified the `.github/pull.yml` configuration to use "rebase" instead of "squash" as the merge method when pulling changes from the upstream springboot3 branch.
- This change preserves the commit history from the upstream repository rather than combining all changes into a single commit.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->